### PR TITLE
Expired Links and Invitation Functionality

### DIFF
--- a/functions/src/clean_invites.ts
+++ b/functions/src/clean_invites.ts
@@ -1,0 +1,31 @@
+import admin from "./firebase";
+import { FriendInviteData } from "../utils/types";
+import * as functions from "firebase-functions";
+
+const firestore = admin.firestore();
+const invitesCollection = firestore.collection(
+  "friend-invites"
+) as FirebaseFirestore.CollectionReference<FriendInviteData>;
+
+/*
+This function is called every week to clean up the friend-invites collection. We only want to keep the invites made in the past week.
+*/
+
+export const cleanInvites = functions.pubsub
+  .schedule("every 1 week")
+  .onRun(async () => {
+    const docs = await invitesCollection.listDocuments();
+    docs.forEach(async (doc) => {
+      const data = await (await doc.get()).data();
+      if (!data) {
+        doc.delete();
+        return;
+      }
+      const diffInDays =
+        (new Date().getTime() - data.created.toDate().getTime()) /
+        (1000 * 3600 * 24);
+      if (diffInDays >= 7) {
+        doc.delete();
+      }
+    });
+  });

--- a/functions/src/clean_invites.ts
+++ b/functions/src/clean_invites.ts
@@ -1,5 +1,9 @@
 import admin from "./firebase";
-import { AnyScheduleData, FriendInviteData, Version3ScheduleData } from "../utils/types";
+import {
+  AnyScheduleData,
+  FriendInviteData,
+  Version3ScheduleData,
+} from "../utils/types";
 import * as functions from "firebase-functions";
 
 const firestore = admin.firestore();
@@ -7,7 +11,9 @@ const invitesCollection = firestore.collection(
   "friend-invites"
 ) as FirebaseFirestore.CollectionReference<FriendInviteData>;
 
-const schedulesCollection = firestore.collection("schedules") as FirebaseFirestore.CollectionReference<AnyScheduleData>
+const schedulesCollection = firestore.collection(
+  "schedules"
+) as FirebaseFirestore.CollectionReference<AnyScheduleData>;
 
 /*
 This function is called every week to clean up the friend-invites collection. We only want to keep the invites made in the past week.
@@ -28,12 +34,16 @@ export const cleanInvites = functions.pubsub
         (1000 * 3600 * 24);
       if (diffInDays >= 7) {
         const senderDoc = await schedulesCollection.doc(data.sender).get();
-        const senderData = await senderDoc.data() as Version3ScheduleData | undefined;
+        const senderData = (await senderDoc.data()) as
+          | Version3ScheduleData
+          | undefined;
         if (!senderData) {
           doc.ref.delete();
           return;
         }
-        delete senderData.terms[data.term].versions[data.version].friends[data.friend];
+        delete senderData.terms[data.term].versions[data.version].friends[
+          data.friend
+        ];
         await senderDoc.ref.set(senderData);
         doc.ref.delete();
       }

--- a/functions/src/clean_invites.ts
+++ b/functions/src/clean_invites.ts
@@ -14,18 +14,18 @@ This function is called every week to clean up the friend-invites collection. We
 export const cleanInvites = functions.pubsub
   .schedule("every 1 week")
   .onRun(async () => {
-    const docs = await invitesCollection.listDocuments();
+    const docs = await invitesCollection.get();
     docs.forEach(async (doc) => {
-      const data = await (await doc.get()).data();
+      const data = await doc.data();
       if (!data) {
-        doc.delete();
+        doc.ref.delete();
         return;
       }
       const diffInDays =
         (new Date().getTime() - data.created.toDate().getTime()) /
         (1000 * 3600 * 24);
       if (diffInDays >= 7) {
-        doc.delete();
+        doc.ref.delete();
       }
     });
   });

--- a/functions/src/clean_invites.ts
+++ b/functions/src/clean_invites.ts
@@ -1,11 +1,13 @@
 import admin from "./firebase";
-import { FriendInviteData } from "../utils/types";
+import { AnyScheduleData, FriendInviteData, Version3ScheduleData } from "../utils/types";
 import * as functions from "firebase-functions";
 
 const firestore = admin.firestore();
 const invitesCollection = firestore.collection(
   "friend-invites"
 ) as FirebaseFirestore.CollectionReference<FriendInviteData>;
+
+const schedulesCollection = firestore.collection("schedules") as FirebaseFirestore.CollectionReference<AnyScheduleData>
 
 /*
 This function is called every week to clean up the friend-invites collection. We only want to keep the invites made in the past week.
@@ -25,6 +27,14 @@ export const cleanInvites = functions.pubsub
         (new Date().getTime() - data.created.toDate().getTime()) /
         (1000 * 3600 * 24);
       if (diffInDays >= 7) {
+        const senderDoc = await schedulesCollection.doc(data.sender).get();
+        const senderData = await senderDoc.data() as Version3ScheduleData | undefined;
+        if (!senderData) {
+          doc.ref.delete();
+          return;
+        }
+        delete senderData.terms[data.term].versions[data.version].friends[data.friend];
+        await senderDoc.ref.set(senderData);
         doc.ref.delete();
       }
     });

--- a/functions/src/create_friend_invitation.ts
+++ b/functions/src/create_friend_invitation.ts
@@ -34,7 +34,7 @@ export const createFriendInvitation = functions.https.onRequest(
           // Do nothing
         }
         const { IDToken, friendEmail, term, version } = request.body;
-        
+
         if (!IDToken) {
           return response.status(401).json(apiError("IDToken not provided"));
         }

--- a/functions/src/create_friend_invitation.ts
+++ b/functions/src/create_friend_invitation.ts
@@ -3,7 +3,11 @@ import * as functions from "firebase-functions";
 import * as cors from "cors";
 import { apiError } from "./api";
 
-import { AnyScheduleData, FriendInviteData, Version3ScheduleData } from "../utils/types";
+import {
+  AnyScheduleData,
+  FriendInviteData,
+  Version3ScheduleData,
+} from "../utils/types";
 import sendInvitation from "../utils/nodemailer/sendInvitation";
 // import { Timestamp } from "@google-cloud/firestore";
 
@@ -18,6 +22,7 @@ const auth = admin.auth();
 
 const corsHandler = cors({ origin: true });
 
+/* This endpoint is called when a user wabts to send an invitation*/
 export const createFriendInvitation = functions.https.onRequest(
   async (request, response) => {
     corsHandler(request, response, async () => {
@@ -48,7 +53,7 @@ export const createFriendInvitation = functions.https.onRequest(
         }
 
         const senderEmail = decodedToken.email;
-        console.log(senderEmail);
+
         if (!senderEmail) {
           return response
             .status(400)
@@ -65,9 +70,10 @@ export const createFriendInvitation = functions.https.onRequest(
         // Get Sender UID from the decoded token
         const senderId = decodedToken.uid;
 
-        // Get Sender record from the schedules collection
+        // Get Sender record from the schedules collection - it has to be version 3 because an invite was sent from it
         const senderRes = await schedulesCollection.doc(senderId).get();
-        const senderData: Version3ScheduleData | undefined = senderRes.data() as Version3ScheduleData | undefined;
+        const senderData: Version3ScheduleData | undefined =
+          senderRes.data() as Version3ScheduleData | undefined;
 
         if (
           !senderData ||
@@ -116,6 +122,7 @@ export const createFriendInvitation = functions.https.onRequest(
         };
         let inviteId;
         try {
+          // Add the invite data to the schedule of the sender
           const addRes = await invitesCollection.add(record);
           if (!senderData.terms[term].versions[version].friends) {
             senderData.terms[term].versions[version].friends = {};

--- a/functions/src/create_friend_invitation.ts
+++ b/functions/src/create_friend_invitation.ts
@@ -156,7 +156,6 @@ export const createFriendInvitation = functions.https.onRequest(
 
         return response.status(200).json({ inviteId });
       } catch (err) {
-        console.error(err);
         return response.status(400).json(apiError("Error creating invite"));
       }
     });

--- a/functions/src/create_friend_invitation.ts
+++ b/functions/src/create_friend_invitation.ts
@@ -31,10 +31,10 @@ export const createFriendInvitation = functions.https.onRequest(
         try {
           request.body = JSON.parse(request.body);
         } catch {
-          return response.status(400).json(apiError("Bad request"));
+          // Do nothing
         }
         const { IDToken, friendEmail, term, version } = request.body;
-
+        
         if (!IDToken) {
           return response.status(401).json(apiError("IDToken not provided"));
         }

--- a/functions/src/fetch_friend_schedules.ts
+++ b/functions/src/fetch_friend_schedules.ts
@@ -48,7 +48,7 @@ export const fetchFriendSchedules = functions.https.onRequest(
         friends == null ||
         Object.keys(friends).length === 0
       ) {
-        return response.status(400).json("Invalid request");
+        return response.status(400).json(apiError("Invalid request"));
       }
 
       let decodedToken: admin.auth.DecodedIdToken;

--- a/functions/src/fetch_friend_schedules.ts
+++ b/functions/src/fetch_friend_schedules.ts
@@ -33,7 +33,7 @@ export const fetchFriendSchedules = functions.https.onRequest(
       try {
         request.body = JSON.parse(request.body);
       } catch {
-        return response.status(400).json(apiError("Bad request"));
+        // Do nothing
       }
 
       const { IDToken, friends, term } = request.body;

--- a/functions/src/handle_friend_invitation.ts
+++ b/functions/src/handle_friend_invitation.ts
@@ -34,7 +34,7 @@ export const handleFriendInvitation = functions.https.onRequest(
         try {
           request.body = JSON.parse(request.body);
         } catch {
-          return response.status(400).json(apiError("Bad request"));
+          // Do nothing
         }
         const { inviteId } = request.body;
 

--- a/functions/src/handle_friend_invitation.ts
+++ b/functions/src/handle_friend_invitation.ts
@@ -3,12 +3,20 @@ import * as functions from "firebase-functions";
 import * as cors from "cors";
 import { apiError } from "./api";
 
-import { FriendInviteData } from "../utils/types";
+import { FriendInviteData, AnyScheduleData, FriendData, Version3ScheduleData } from "../utils/types";
 
 const firestore = admin.firestore();
 const invitesCollection = firestore.collection(
   "friend-invites"
 ) as FirebaseFirestore.CollectionReference<FriendInviteData>;
+
+const schedulesCollection = firestore.collection(
+  "schedules"
+) as FirebaseFirestore.CollectionReference<AnyScheduleData>;
+
+const friendsCollection = firestore.collection(
+  "friends"
+) as FirebaseFirestore.CollectionReference<FriendData>;
 
 const corsHandler = cors({ origin: true });
 
@@ -23,20 +31,79 @@ export const handleFriendInvitation = functions.https.onRequest(
           return response.status(400).json(apiError("Bad request"));
         }
         const { inviteId } = request.body;
+
         if (!inviteId) {
           return response
             .status(401)
             .json(apiError("Invalid invite id provided"));
         }
 
-        await invitesCollection.doc(inviteId).delete();
+        const inviteDoc = await invitesCollection.doc(inviteId).get();
+        console.log(inviteDoc);
+        if (!inviteDoc.exists) {
+          return response
+            .status(400)
+            .json(
+              apiError("This link has either expired or has already been used")
+            );
+        }
 
-        // perform further functionality
+        // Delete the invite regardless of whether it is valid or not
+        // await invitesCollection.doc(inviteId).delete();
 
-        return response.status(202).send();
+        const inviteData = await inviteDoc.data();
+        console.log(inviteData);
+        if (!inviteData) {
+          return response
+            .status(401)
+            .json(apiError("Could not find the record for this link"));
+        }
+
+        const senderSchedule: Version3ScheduleData | undefined = await (
+          await schedulesCollection.doc(inviteData.sender).get()
+        ).data() as Version3ScheduleData | undefined;
+
+        if (!senderSchedule) {
+          return response
+            .status(400)
+            .json(apiError("The sender's account has been deleted"));
+        }
+
+        // Check if link hasn't expired
+        const diffInDays =
+          (new Date().getTime() - inviteData.created.toDate().getTime()) /
+          (1000 * 3600 * 24);
+
+        if (diffInDays >= 7) {
+          delete senderSchedule.terms[inviteData.term].versions[
+            inviteData.version
+          ].friends[inviteData.friend];
+          await inviteDoc.ref.delete();
+          return response
+            .status(400)
+            .json(apiError("The invitation link has expired"));
+        } else {
+          senderSchedule.terms[inviteData.term].versions[
+            inviteData.version
+          ].friends[inviteData.friend].status = "Accepted";
+
+          let friendRecord: FriendData | undefined = await (
+            await friendsCollection.doc(inviteData.friend).get()
+          ).data();
+          if (!friendRecord) {
+            friendRecord = { terms: {} };
+            friendRecord.terms[inviteData.term] = { accessibleSchedules: {} };
+            friendRecord.terms[inviteData.term].accessibleSchedules[
+              inviteData.sender
+            ] = [inviteData.version];
+          }
+          await friendsCollection.doc(inviteData.friend).set(friendRecord);
+          await schedulesCollection.doc(inviteData.sender).set(senderSchedule);
+          await inviteDoc.ref.delete();
+          return response.status(202).send();
+        }
       } catch (err) {
-        console.error(err);
-        return response.status(400).json(apiError("Error deleting invite"));
+        return response.status(400).json(apiError("Error accepting invite"));
       }
     });
   }

--- a/functions/utils/types.ts
+++ b/functions/utils/types.ts
@@ -1,10 +1,13 @@
 // This file is a compilation of Firebase collections' data schemas.
 
+import { Timestamp } from "@google-cloud/firestore";
+
 export interface FriendInviteData {
   friend: string;
   sender: string;
   term: string;
   version: string;
+  created: Timestamp;
 }
 
 // This type should automatically accept any schedule data
@@ -63,6 +66,12 @@ export interface Version3ScheduleVersion {
   name: string;
   createdAt: string;
   schedule: Version3Schedule;
+  friends: Record<string, FriendShareData>;
+}
+
+export interface FriendShareData {
+  status: "Pending" | "Accepted";
+  email: string;
 }
 
 export interface Version3Schedule {


### PR DESCRIPTION
Resolves [#174](https://github.com/gt-scheduler/website/issues/174)

Added a pub/sub function to check for expired links every week which deletes invites from the invites collection if they are expired and also deletes the invites from the sender's schedule collection.

### Checkllist
- [x] A new field is added to the `friend-invites` collection/schema to track time.
- [x] If an expired invite link is clicked, it should return some response and delete the friend from the invited list in the `schedules` collection.
- [x] A new cloud function is added to clean up expired invitations every 7 days.

### How to test
Start the cloud function emulator and send a request from the front end using the invitation modal.
I was not able to test the pub/sub function but it should work as expected because it is very similar to the code in the handle invitation function.