### PR TITLE
Support Different Request Content Type

### DIFF
--- a/functions/src/create_friend_invitation.ts
+++ b/functions/src/create_friend_invitation.ts
@@ -23,7 +23,7 @@ export const createFriendInvitation = functions.https.onRequest(
         try {
           request.body = JSON.parse(request.body);
         } catch {
-          return response.status(400).json(apiError("Bad request"));
+          // Do nothing
         }
         const { IDToken, friendEmail, term, version } = request.body;
         if (!IDToken) {

--- a/functions/src/fetch_friend_schedules.ts
+++ b/functions/src/fetch_friend_schedules.ts
@@ -31,16 +31,12 @@ export const fetchFriendSchedules = functions.https.onRequest(
   async (request, response) => {
     corsHandler(request, response, async () => {
       try {
-        // If request is sent using fetch
-        request.body = JSON.parse(request.body);
+        // This request should be made with content type is application/x-www-form-urlencoded.
+        // This is done to prevent a pre-flight CORS request made to the firebase function
+        // Refer: https://github.com/gt-scheduler/website/pull/187#issuecomment-1496439246
+        request.body = JSON.parse(request.body.data);
       } catch {
-        try {
-          // If request is sent using axios and content type is application/x-www-form-urlencoded
-          request.body = JSON.parse(request.body.data);
-        } catch {
-          // If request is sent using axios and content type is application/json
-          // Do nothing
-        }
+        response.status(401).json(apiError("Bad request"));
       }
 
       const { IDToken, friends, term } = request.body;

--- a/functions/src/fetch_friend_schedules.ts
+++ b/functions/src/fetch_friend_schedules.ts
@@ -31,9 +31,16 @@ export const fetchFriendSchedules = functions.https.onRequest(
   async (request, response) => {
     corsHandler(request, response, async () => {
       try {
+        // If request is sent using fetch
         request.body = JSON.parse(request.body);
       } catch {
-        return response.status(400).json(apiError("Bad request"));
+        try {
+          // If request is sent using axios and content type is application/x-www-form-urlencoded
+          request.body = JSON.parse(request.body.data);
+        } catch {
+          // If request is sent using axios and content type is application/json
+          // Do nothing
+        }
       }
 
       const { IDToken, friends, term } = request.body;
@@ -48,7 +55,7 @@ export const fetchFriendSchedules = functions.https.onRequest(
         friends == null ||
         Object.keys(friends).length === 0
       ) {
-        return response.status(400).json("Invalid request");
+        return response.status(400).json(apiError("Invalid request"));
       }
 
       let decodedToken: admin.auth.DecodedIdToken;

--- a/functions/src/handle_friend_invitation.ts
+++ b/functions/src/handle_friend_invitation.ts
@@ -20,7 +20,7 @@ export const handleFriendInvitation = functions.https.onRequest(
         try {
           request.body = JSON.parse(request.body);
         } catch {
-          return response.status(400).json(apiError("Bad request"));
+          // Do nothing
         }
         const { inviteId } = request.body;
         if (!inviteId) {


### PR DESCRIPTION
Supports `application/x-www-form-urlencoded` content type for requests to the `fetchFriendSchedule` endpoint.
Refer PR: https://github.com/gt-scheduler/website/pull/216