### PR TITLE
Upgrade functions from node version 18 -> 22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: functions  
+        working-directory: functions
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install
         run: yarn install --frozen-lockfile

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,7 @@
     "secrets:get": "bw sync && bw get item gt-scheduler/firebase-conf/.env | fx .notes > \".env\""
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "main": "lib/src/index.js",
   "dependencies": {

--- a/functions/src/handle_friend_invitation.ts
+++ b/functions/src/handle_friend_invitation.ts
@@ -85,10 +85,10 @@ export const handleFriendInvitation = functions
         Object.keys(senderSchedule.terms).forEach((t) => {
           Object.keys(senderSchedule.terms[t].versions).forEach((v) => {
             if (!senderSchedule.terms[t].versions[v].friends) {
-              senderSchedule.terms[t].versions[v].friends = {}
+              senderSchedule.terms[t].versions[v].friends = {};
             }
-          })
-        })
+          });
+        });
 
         // Check if link hasn't expired by calculating the difference between the current time and the time the link was created
         const defaultValidDuration = 7 * 24 * 60 * 60;
@@ -199,7 +199,7 @@ export const handleFriendInvitation = functions
           term: inviteData.term,
         });
       } catch (err) {
-        console.log(err)
+        console.log(err);
         return response.status(400).json(apiError("unkown-error"));
       }
     });


### PR DESCRIPTION
```
Runtime Node.js 18 was deprecated on 2025-04-30 and will be decommissioned on 2025-10-30, after which you will not be able to deploy without upgrading
```
### Testing
```sh
nvm use 22
```
```sh
firebase deploy --project dev
```
Tested functions by utilizing website:
- [x] course_critique_cache
- [x] create_friend_invitation
- [x] create_friend_invitation_link
- [x] delete_shared_schedule
- [x] fetch_friend_schedules
