### PR TITLE
Submit Ratings and Get Rating Stats

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -12,5 +12,20 @@ service cloud.firestore {
     match /friends/{userId}/{documents=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId
     }
+
+    match /ratings/{document=**} {
+      allow read, write: if false;
+    }
+
+    match /courseStats/{document=**} {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    match /professorStats/{document=**} {
+      allow read: if true;
+      allow write: if false;
+    }
   }
+
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -29,7 +29,8 @@
     "firebase-functions": "^3.14",
     "node-fetch": "^2",
     "nodemailer": "^6.9.1",
-    "yarn": "^1.22.19"
+    "yarn": "^1.22.19",
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@types/date-and-time": "^0.13.0",

--- a/functions/src/backup_firestore.ts
+++ b/functions/src/backup_firestore.ts
@@ -5,7 +5,7 @@ const firestoreClient = new firestore.v1.FirestoreAdminClient();
 
 // Add collection IDs here to include them in backups.
 // Leave empty to export all collections.
-const backedUpCollections = ["schedules"];
+const backedUpCollections = ["schedules", "ratings"];
 const bucket = "gs://gt-scheduler-web-prod-firestore-backup";
 
 /**

--- a/functions/src/get_rating_stats.ts
+++ b/functions/src/get_rating_stats.ts
@@ -1,0 +1,85 @@
+import admin from "./firebase";
+import * as functions from "firebase-functions";
+import * as cors from "cors";
+import { apiError } from "./api";
+import {
+  GetRatingsRequestData,
+  GetRatingsRequestDataSchema,
+} from "../utils/types";
+import { DocumentData } from "@google-cloud/firestore";
+
+const firestore = admin.firestore();
+const corsHandler = cors({ origin: true });
+
+// TODO: validate types before and after
+function normalizeStats(doc: FirebaseFirestore.DocumentData) {
+  if (!doc || doc.reviewCount === 0) return null;
+
+  return {
+    averageRating: doc.sumOverallRating / doc.reviewCount,
+    averageDifficulty: doc.sumDifficulty / doc.reviewCount,
+    averageWorkload: doc.sumWorkload / doc.reviewCount,
+    reviewCount: doc.reviewCount,
+  };
+}
+
+export const getRatingStats = functions
+  .region("us-east1")
+  .https.onRequest(async (request, response) => {
+    corsHandler(request, response, async () => {
+      try {
+        try {
+          request.body = JSON.parse(request.body.data);
+        } catch {
+          return response.status(400).json(apiError("Bad request"));
+        }
+
+        const parsed = GetRatingsRequestDataSchema.safeParse(request.body);
+        if (!parsed.success) {
+          return response.status(400).json(apiError("Invalid request payload"));
+        }
+
+        const { courses, professors } = parsed.data as GetRatingsRequestData;
+
+        const result: any = {
+          courses: {},
+          professors: {},
+        };
+
+        if (courses?.length) {
+          const courseDocs = await firestore.getAll(
+            ...courses.map((id) => firestore.collection("courseStats").doc(id))
+          );
+
+          courseDocs.forEach((doc, idx) => {
+            if (doc.exists) {
+              result.courses[courses[idx]] = normalizeStats(
+                doc.data() as DocumentData
+              );
+            }
+          });
+        }
+
+        if (professors?.length) {
+          const profDocs = await firestore.getAll(
+            ...professors.map((id) =>
+              firestore.collection("professorStats").doc(id)
+            )
+          );
+
+          profDocs.forEach((doc, idx) => {
+            if (doc.exists) {
+              result.professors[professors[idx]] = normalizeStats(
+                doc.data() as DocumentData
+              );
+            }
+          });
+        }
+
+        return response.status(200).json(result);
+      } catch (err) {
+        console.error(err);
+        return response.status(400).json(apiError("Failed to fetch stats"));
+      }
+    });
+  });

--- a/functions/src/get_rating_stats.ts
+++ b/functions/src/get_rating_stats.ts
@@ -5,21 +5,33 @@ import { apiError } from "./api";
 import {
   GetRatingsRequestData,
   GetRatingsRequestDataSchema,
+  NormalizedStat,
+  RatingStatDataSchema,
+  RatingStatsResponse,
 } from "../utils/types";
 import { DocumentData } from "@google-cloud/firestore";
 
 const firestore = admin.firestore();
 const corsHandler = cors({ origin: true });
 
-// TODO: validate types before and after
-function normalizeStats(doc: FirebaseFirestore.DocumentData) {
-  if (!doc || doc.reviewCount === 0) return null;
+function normalizeStats(
+  data: FirebaseFirestore.DocumentData | undefined
+): NormalizedStat | null {
+  if (!data) return null;
+
+  const parsed = RatingStatDataSchema.safeParse(data);
+  if (!parsed.success) return null;
+
+  const { sumOverallRating, sumDifficulty, sumWorkload, reviewCount } =
+    parsed.data;
+
+  if (reviewCount === 0) return null;
 
   return {
-    averageRating: doc.sumOverallRating / doc.reviewCount,
-    averageDifficulty: doc.sumDifficulty / doc.reviewCount,
-    averageWorkload: doc.sumWorkload / doc.reviewCount,
-    reviewCount: doc.reviewCount,
+    averageRating: sumOverallRating / reviewCount,
+    averageDifficulty: sumDifficulty / reviewCount,
+    averageWorkload: sumWorkload / reviewCount,
+    reviewCount,
   };
 }
 
@@ -41,7 +53,7 @@ export const getRatingStats = functions
 
         const { courses, professors } = parsed.data as GetRatingsRequestData;
 
-        const result: any = {
+        const result: RatingStatsResponse = {
           courses: {},
           professors: {},
         };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,3 +5,4 @@ export { createFriendInvitationLink } from "./create_friend_invitation_link";
 export { handleFriendInvitation } from "./handle_friend_invitation";
 export { fetchFriendSchedules } from "./fetch_friend_schedules";
 export { deleteSharedSchedule } from "./delete_shared_schedule";
+export { submitRatings } from "./submit_ratings";

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,3 +6,4 @@ export { handleFriendInvitation } from "./handle_friend_invitation";
 export { fetchFriendSchedules } from "./fetch_friend_schedules";
 export { deleteSharedSchedule } from "./delete_shared_schedule";
 export { submitRatings } from "./submit_ratings";
+export { getRatingStats } from "./get_rating_stats";

--- a/functions/src/submit_ratings.ts
+++ b/functions/src/submit_ratings.ts
@@ -11,7 +11,6 @@ const firestore = admin.firestore();
 const auth = admin.auth();
 const corsHandler = cors({ origin: true });
 
-//TODO: figure out behavior when a user submits multiple ratings for the same course/professor/term combination
 export const submitRatings = functions
   .region("us-east1")
   .https.onRequest(async (request, response) => {
@@ -66,7 +65,6 @@ export const submitRatings = functions
 
             const ratingRef = firestore.collection("ratings").doc();
 
-            // TODO: cast as type here and for stats
             // Insert rating
             tx.set(ratingRef, {
               userId,
@@ -79,31 +77,19 @@ export const submitRatings = functions
               createdAt: admin.firestore.FieldValue.serverTimestamp(),
             });
 
+            const statUpdate = {
+              sumOverallRating: admin.firestore.FieldValue.increment(rating),
+              sumDifficulty: admin.firestore.FieldValue.increment(difficulty),
+              sumWorkload: admin.firestore.FieldValue.increment(workload),
+              reviewCount: admin.firestore.FieldValue.increment(1),
+              lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+            };
+
             // Update course stats
-            tx.set(
-              courseStatsRef,
-              {
-                sumOverallRating: admin.firestore.FieldValue.increment(rating),
-                sumDifficulty: admin.firestore.FieldValue.increment(difficulty),
-                sumWorkload: admin.firestore.FieldValue.increment(workload),
-                reviewCount: admin.firestore.FieldValue.increment(1),
-                lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
-              },
-              { merge: true }
-            );
+            tx.set(courseStatsRef, statUpdate, { merge: true });
 
             // Update professor stats
-            tx.set(
-              professorStatsRef,
-              {
-                sumOverallRating: admin.firestore.FieldValue.increment(rating),
-                sumDifficulty: admin.firestore.FieldValue.increment(difficulty),
-                sumWorkload: admin.firestore.FieldValue.increment(workload),
-                reviewCount: admin.firestore.FieldValue.increment(1),
-                lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
-              },
-              { merge: true }
-            );
+            tx.set(professorStatsRef, statUpdate, { merge: true });
           }
         });
 

--- a/functions/src/submit_ratings.ts
+++ b/functions/src/submit_ratings.ts
@@ -1,0 +1,115 @@
+import admin from "./firebase";
+import * as functions from "firebase-functions";
+import * as cors from "cors";
+import { apiError } from "./api";
+import {
+  SubmitRatingsRequestData,
+  SubmitRatingsRequestDataSchema,
+} from "../utils/types";
+
+const firestore = admin.firestore();
+const auth = admin.auth();
+const corsHandler = cors({ origin: true });
+
+//TODO: figure out behavior when a user submits multiple ratings for the same course/professor/term combination
+export const submitRatings = functions
+  .region("us-east1")
+  .https.onRequest(async (request, response) => {
+    corsHandler(request, response, async () => {
+      try {
+        try {
+          // This request should be made with content type is application/x-www-form-urlencoded.
+          // This is done to prevent a pre-flight CORS request made to the firebase function
+          // Refer: https://github.com/gt-scheduler/website/pull/187#issuecomment-1496439246
+          request.body = JSON.parse(request.body.data);
+        } catch {
+          return response.status(401).json(apiError("Bad request"));
+        }
+
+        // Validate payload
+        const parsed = SubmitRatingsRequestDataSchema.safeParse(request.body);
+
+        if (!parsed.success) {
+          return response.status(400).json(apiError("Invalid request payload"));
+        }
+
+        const { IDToken, ratings } = parsed.data as SubmitRatingsRequestData;
+
+        // Authenticate user
+        let decodedToken: admin.auth.DecodedIdToken;
+        try {
+          decodedToken = await auth.verifyIdToken(IDToken);
+        } catch {
+          return response.status(401).json(apiError("User not found"));
+        }
+
+        const userId = decodedToken.uid;
+
+        await firestore.runTransaction(async (tx) => {
+          for (const r of ratings) {
+            const {
+              courseId,
+              professorId,
+              term,
+              rating,
+              difficulty,
+              workload,
+            } = r;
+
+            const courseStatsRef = firestore
+              .collection("courseStats")
+              .doc(courseId);
+
+            const professorStatsRef = firestore
+              .collection("professorStats")
+              .doc(professorId);
+
+            const ratingRef = firestore.collection("ratings").doc();
+
+            // Insert rating
+            tx.set(ratingRef, {
+              userId,
+              courseId,
+              professorId,
+              term,
+              rating,
+              difficulty,
+              workload,
+              createdAt: admin.firestore.FieldValue.serverTimestamp(),
+            });
+
+            // Update course stats
+            tx.set(
+              courseStatsRef,
+              {
+                sumOverallRating: admin.firestore.FieldValue.increment(rating),
+                sumDifficulty: admin.firestore.FieldValue.increment(difficulty),
+                sumWorkload: admin.firestore.FieldValue.increment(workload),
+                reviewCount: admin.firestore.FieldValue.increment(1),
+                lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+              },
+              { merge: true }
+            );
+
+            // Update professor stats
+            tx.set(
+              professorStatsRef,
+              {
+                sumOverallRating: admin.firestore.FieldValue.increment(rating),
+                sumDifficulty: admin.firestore.FieldValue.increment(difficulty),
+                sumWorkload: admin.firestore.FieldValue.increment(workload),
+                reviewCount: admin.firestore.FieldValue.increment(1),
+                lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+              },
+              { merge: true }
+            );
+          }
+        });
+
+        return response.status(200).json({ success: true });
+      } catch (err) {
+        console.error(err);
+        return response.status(400).json(apiError("Error creating invite"));
+      }
+    });
+  });

--- a/functions/src/submit_ratings.ts
+++ b/functions/src/submit_ratings.ts
@@ -66,6 +66,7 @@ export const submitRatings = functions
 
             const ratingRef = firestore.collection("ratings").doc();
 
+            // TODO: cast as type here and for stats
             // Insert rating
             tx.set(ratingRef, {
               userId,

--- a/functions/utils/types.ts
+++ b/functions/utils/types.ts
@@ -153,7 +153,7 @@ const Rating = z.object({
   term: z.number(),
   rating: z.number().min(1).max(5),
   difficulty: z.number().min(1).max(5),
-  workload: z.number(),
+  workload: z.number().min(0),
 });
 
 export const SubmitRatingsRequestDataSchema = z.object({
@@ -175,3 +175,26 @@ export const GetRatingsRequestDataSchema = z
   });
 
 export type GetRatingsRequestData = z.infer<typeof GetRatingsRequestDataSchema>;
+
+export const RatingStatDataSchema = z.object({
+  sumOverallRating: z.number(),
+  sumDifficulty: z.number(),
+  sumWorkload: z.number(),
+  reviewCount: z.number().int().nonnegative(),
+});
+
+const NormalizedStatSchema = z.object({
+  averageRating: z.number().nonnegative(),
+  averageDifficulty: z.number().nonnegative(),
+  averageWorkload: z.number().nonnegative(),
+  reviewCount: z.number().int().nonnegative(),
+});
+
+export type NormalizedStat = z.infer<typeof NormalizedStatSchema>;
+
+const RatingStatsResponseSchema = z.object({
+  courses: z.record(z.string(), NormalizedStatSchema.nullable()),
+  professors: z.record(z.string(), NormalizedStatSchema.nullable()),
+});
+
+export type RatingStatsResponse = z.infer<typeof RatingStatsResponseSchema>;

--- a/functions/utils/types.ts
+++ b/functions/utils/types.ts
@@ -1,5 +1,5 @@
 // This file is a compilation of Firebase collections' data schemas.
-
+import { z } from "zod";
 import { Timestamp } from "@google-cloud/firestore";
 
 export interface FriendInviteData {
@@ -138,3 +138,29 @@ export type ScheduleDeletionRequest = {
    */
   owner: boolean;
 };
+
+/**
+ * While we do not use Zod in the other functions and do all validations manually,
+ * this is not a good practice and we should migrate to using Zod for all request validations eventually.
+ * For right now, we will leave the other functions as is and only use Zod for new functions.
+ *
+ * The submit ratings request schema in particular benefits from Zod due to the nested structure and multiple constraints.
+ */
+
+const Rating = z.object({
+  courseId: z.string(),
+  professorId: z.string(),
+  term: z.number(),
+  rating: z.number().min(1).max(5),
+  difficulty: z.number().min(1).max(5),
+  workload: z.number(),
+});
+
+export const SubmitRatingsRequestDataSchema = z.object({
+  IDToken: z.string(),
+  ratings: z.array(Rating).min(1),
+});
+
+export type SubmitRatingsRequestData = z.infer<
+  typeof SubmitRatingsRequestDataSchema
+>;

--- a/functions/utils/types.ts
+++ b/functions/utils/types.ts
@@ -164,3 +164,14 @@ export const SubmitRatingsRequestDataSchema = z.object({
 export type SubmitRatingsRequestData = z.infer<
   typeof SubmitRatingsRequestDataSchema
 >;
+
+export const GetRatingsRequestDataSchema = z
+  .object({
+    courses: z.array(z.string()).optional(),
+    professors: z.array(z.string()).optional(),
+  })
+  .refine((v) => (v.courses?.length || 0) + (v.professors?.length || 0) > 0, {
+    message: "At least one course or professor must be specified",
+  });
+
+export type GetRatingsRequestData = z.infer<typeof GetRatingsRequestDataSchema>;

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -3298,3 +3298,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
## Summary
This PR creates two firebase functions. One to submit ratings and one to get them. The ones that gets them actually gets an aggregate record instead of iterating through everything submitted.

A detailed description of the issue is here #28 

## Test Plan
Run with 
`cd functions && yarn build`
`firebase emulators:start`

You can either get an ID token from the frontend or comment the auth part to test which is what I did.

### Sample curl commands:
To submit a rating
```
curl -X POST http://localhost:5001/gt-scheduler-web-dev/us-east1/submitRatings -H  'data={"IDToken":"abc",
    "ratings":[
      {
        "courseId":"LMC-3705",
        "professorId":"john-doe",
        "term":202508,
        "rating":5,
        "difficulty":2,
        "workload":2
      }
    ]
  }'
```

To get a rating
```
curl -X POST http://localhost:5001/gt-scheduler-web-dev/us-east1/getRatingStats \
  -H "Content-Type: application/x-www-form-urlencoded" \
  --data-urlencode 'data={
    "courses": ["LMC-3705"],
    "professors": []
  }
  '
  ```